### PR TITLE
ops(worker): pin custom domain to repogotchi.cortech.online

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Test totals: **89 JS + 5 Swift = 94**.
 ### Soon — close the cross-surface gaps
 
 4. **Resolve the palette divergence between CLI and Worker** ([#2](https://github.com/schmug/RepoGotchi/issues/2)). Worker uses GitHub-detected language; CLI doesn't, so the same repo gets two different pets. Detect from file extensions in the CLI.
-5. **Deploy the Worker** ([#4](https://github.com/schmug/RepoGotchi/issues/4)) to a real hostname (e.g. `repogotchi.app`). Wrangler config + domain + DNS. One-time setup.
+5. **Deploy the Worker** ([#4](https://github.com/schmug/RepoGotchi/issues/4)) to `repogotchi.cortech.online`. Wrangler config landed; remaining work is `wrangler login` → `wrangler secret put GITHUB_TOKEN` → `wrangler deploy`, then swap the root README badge example to the live URL.
 
 ### Later — quality + delight
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,15 +1,35 @@
 # Worker
 
-Cloudflare Worker serving `GET /pet/:owner/:repo.svg`. Fetches GitHub stats, computes scores via `@repogotchi/core`, renders via `@repogotchi/render-svg`, caches in KV with a 1h TTL.
+Cloudflare Worker serving `GET /pet/:owner/:repo.svg`. Fetches GitHub stats, computes scores via `@repogotchi/core`, renders via `@repogotchi/render-svg`, and relies on Cloudflare's edge cache (`Cache-Control: public, max-age=3600, s-maxage=3600`) — no KV in v0.
 
 Returns an SVG suitable for embedding in any GitHub README:
 
 ```markdown
-![pet](https://repogotchi.app/pet/<owner>/<repo>.svg)
+![pet](https://repogotchi.cortech.online/pet/<owner>/<repo>.svg)
 ```
 
 Depends on: `@repogotchi/core`, `@repogotchi/render-svg`, `@repogotchi/contract`.
 
+## Deploy
+
+One-time setup (per Cloudflare account):
+
+```bash
+wrangler login
+wrangler secret put GITHUB_TOKEN   # fine-grained PAT, public_repo read
+```
+
+The `cortech.online` zone must be active in the same Cloudflare account before `wrangler deploy` will accept the `custom_domain` binding in [wrangler.toml](wrangler.toml).
+
+Routine deploys:
+
+```bash
+pnpm --filter @repogotchi/worker deploy
+curl https://repogotchi.cortech.online/pet/schmug/RepoGotchi.svg
+```
+
+The `workers_dev = true` fallback (`repogotchi-worker.<account>.workers.dev`) is always on — handy for verifying a bundle before DNS propagates.
+
 ## Status
 
-Planned. Initial route + cache pattern adapted from [schmug/repo-pet's Express endpoint](https://github.com/schmug/repo-pet/blob/master/server/petEndpoint.ts).
+Code shipped (14 tests). Hostname configured to `repogotchi.cortech.online`; awaiting first deploy. Initial route + cache pattern adapted from [schmug/repo-pet's Express endpoint](https://github.com/schmug/repo-pet/blob/master/server/petEndpoint.ts).

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -2,6 +2,17 @@ name = "repogotchi-worker"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
+# Always-on workers.dev fallback (repogotchi-worker.<account>.workers.dev).
+# Useful for smoke-testing a deploy before DNS propagates.
+workers_dev = true
+
+# Production hostname. Requires the cortech.online zone to live in the same
+# Cloudflare account that runs `wrangler deploy`. Cloudflare provisions DNS +
+# TLS automatically when `custom_domain = true`.
+[[routes]]
+pattern = "repogotchi.cortech.online"
+custom_domain = true
+
 # Local dev:  pnpm --filter @repogotchi/worker dev
 # Deploy:     pnpm --filter @repogotchi/worker deploy   (requires `wrangler login`)
 #


### PR DESCRIPTION
## Summary

- Adds the wrangler route binding (`custom_domain = true`) for `repogotchi.cortech.online` plus an explicit `workers_dev = true` fallback in [apps/worker/wrangler.toml](apps/worker/wrangler.toml).
- Replaces the `repogotchi.app` placeholder in [apps/worker/README.md](apps/worker/README.md) with the chosen host and adds concrete deploy steps.
- Updates [ROADMAP.md](ROADMAP.md) item #5 to reflect the host choice and remaining manual steps.

Config-only. The actual `wrangler deploy` is intentionally not wired into CI in this PR — see "Post-merge steps" below.

## Pre-req

The `cortech.online` zone must be active in the same Cloudflare account that runs `wrangler deploy`, otherwise the `custom_domain` binding will be rejected. (Owner already holds the domain; one-time CF zone add if not already there.)

## Post-merge steps

```bash
wrangler login
wrangler secret put GITHUB_TOKEN     # fine-grained PAT, public_repo read
pnpm --filter @repogotchi/worker deploy
curl https://repogotchi.cortech.online/pet/schmug/RepoGotchi.svg
```

Once the live URL returns 200 with `Content-Type: image/svg+xml`, file the follow-up to swap the root README badge example to the live Worker URL (separate PR — keeps a dead link out of `main` until then).

## Test plan

- [x] `pnpm --filter @repogotchi/worker exec wrangler deploy --dry-run` — bundle still 19.05 KiB / 5.98 KiB gzipped, no errors.
- [x] `pnpm --filter @repogotchi/worker test` — 14/14 pass.
- [ ] (post-merge) `wrangler deploy` succeeds and live URL serves a valid SVG.

Refs #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)