### PR TITLE
docs(readme): add live Worker badge example (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 A pet for every repo. One shared contract — `pet.json` (identity) + `state.json` (live) — drives three surfaces:
 
-- **GitHub Action** — runs in CI, commits `.repogotchi/pet.svg` back to the repo. Embed it in your README:
+- **GitHub Action** — runs in CI, commits `.repogotchi/pet.svg` back to the repo. Works offline and inside CI; updates only when the workflow runs. Embed it in your README:
   ```markdown
   ![pet](.repogotchi/pet.svg)
   ```
-- **Cloudflare Worker** — `GET /pet/:owner/:repo.svg`. Live, cached, zero-storage.
+- **Cloudflare Worker** — `GET /pet/:owner/:repo.svg`. Live, edge-cached, zero-storage; reflects the repo's current state without committing anything. Embed it in your README:
+  ```markdown
+  ![pet](https://repogotchi.cortech.online/pet/<owner>/<repo>.svg)
+  ```
 - **Local CLI** — `repogotchi` reads your working repo's git signals and writes pet/state files under `~/.repogotchi/`.
 - **macOS menubar companion** — Swift app that watches `~/.repogotchi/` and reflects the active repo's pet in your menubar.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Last updated: 2026-05-03 (commit `39d1198`).
 | `@repogotchi/contract`     | shipped  | JSON Schemas + TS/Swift codegen, drift-checked in CI. 6 tests.                   |
 | `@repogotchi/core`         | shipped  | Scoring, mood, level/evolution, headline, hatchPet, petIdFor. 30 tests.          |
 | `@repogotchi/render-svg`   | shipped  | Procedural SVG, deterministic, runs in browser/Node/Workers. 17 tests.           |
-| `@repogotchi/worker`       | shipped  | Cloudflare Worker `/pet/:owner/:repo.svg`. 14 tests. Not deployed.               |
+| `@repogotchi/worker`       | shipped  | Cloudflare Worker `/pet/:owner/:repo.svg`. 14 tests. Deployed at `repogotchi.cortech.online`. |
 | `@repogotchi/cli`          | shipped  | `init` / `compute` / `render` / `status`. 20 tests. Not published to npm.        |
 | `@repogotchi/action`       | shipped  | GitHub Action with bundled `dist/`. 2 tests. Dogfooded via the workflow below.   |
 | `apps/macos-companion`     | shipped  | Swift menubar app + companion core lib. 5 tests. Not packaged/notarized.         |
@@ -36,7 +36,7 @@ Test totals: **89 JS + 5 Swift = 94**.
 ### Soon — close the cross-surface gaps
 
 4. **Resolve the palette divergence between CLI and Worker** ([#2](https://github.com/schmug/RepoGotchi/issues/2)). Worker uses GitHub-detected language; CLI doesn't, so the same repo gets two different pets. Detect from file extensions in the CLI.
-5. **Deploy the Worker** ([#4](https://github.com/schmug/RepoGotchi/issues/4)) to `repogotchi.cortech.online`. Wrangler config landed; remaining work is `wrangler login` → `wrangler secret put GITHUB_TOKEN` → `wrangler deploy`, then swap the root README badge example to the live URL.
+5. ~~**Deploy the Worker** ([#4](https://github.com/schmug/RepoGotchi/issues/4)) to `repogotchi.cortech.online`.~~ Shipped 2026-05-03; `GET /pet/:owner/:repo.svg` is live with `GITHUB_TOKEN` set.
 
 ### Later — quality + delight
 


### PR DESCRIPTION
## Summary

- Worker is deployed at `https://repogotchi.cortech.online` (closes #4); README now embeds the live URL as a peer to the existing Action embed.
- Both surfaces coexist: Action = offline / inside CI; Worker = live, no commits.
- ROADMAP item #5 marked shipped; status snapshot row for `@repogotchi/worker` updated from "Not deployed" to the real hostname.

## Verification

`curl -i https://repogotchi.cortech.online/pet/schmug/RepoGotchi.svg`:
- HTTP 200
- `content-type: image/svg+xml; charset=utf-8`
- `cache-control: public, max-age=3600, s-maxage=3600`

`curl -i https://repogotchi.cortech.online/pet/schmug/this-repo-does-not-exist-9c4e.svg`:
- HTTP 404
- `content-type: image/svg+xml; charset=utf-8`
- Body is the error fallback SVG (per #4's acceptance criteria).

`GITHUB_TOKEN` secret is set on the Worker (5000/hr authenticated rate limit).

## Test plan

- [x] curl live URL returns 200 + correct headers
- [x] curl non-existent repo returns 404 + fallback SVG
- [x] README example renders the badge on this PR's preview (GitHub will hit the live URL)
- [ ] Manual: confirm the rendered badge looks right after PR merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)