### PR TITLE
docs(readme): dogfood RepoGotchi's own pet at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # RepoGotchi
 
+<p align="center">
+  <a href=".repogotchi/pet.svg" title="Action embed — committed by the workflow">
+    <img src=".repogotchi/pet.svg" alt="RepoGotchi pet (Action embed)" width="200" />
+  </a>
+  &nbsp;&nbsp;
+  <a href="https://repogotchi.cortech.online/pet/schmug/RepoGotchi.svg" title="Worker embed — live, edge-cached">
+    <img src="https://repogotchi.cortech.online/pet/schmug/RepoGotchi.svg" alt="RepoGotchi pet (Worker embed)" width="200" />
+  </a>
+</p>
+
+<p align="center"><sub>Left: <code>.repogotchi/pet.svg</code> (Action). Right: <code>repogotchi.cortech.online</code> (Worker). Both rendered from this repo's signals.</sub></p>
+
 A pet for every repo. One shared contract — `pet.json` (identity) + `state.json` (live) — drives three surfaces:
 
 - **GitHub Action** — runs in CI, commits `.repogotchi/pet.svg` back to the repo. Works offline and inside CI; updates only when the workflow runs. Embed it in your README:


### PR DESCRIPTION
## Summary

- The README now shows both the Action-committed `.repogotchi/pet.svg` and the live Worker URL `repogotchi.cortech.online/pet/schmug/RepoGotchi.svg` as side-by-side badges at the top.
- Centered via `<p align="center">` (GitHub renders this correctly in README previews) and constrained to 200px each so the pet doesn't dominate the page.
- Caption distinguishes the two surfaces, reinforcing what the rest of the README explains.

## Why

Until now we documented two embed patterns but rendered neither — the canonical RepoGotchi repo wasn't dogfooding its own pet. This puts the proof at the top of the page.

## Test plan

- [x] `git diff` reviewed; only README.md changes (+12 lines).
- [ ] After merge: confirm both badges render correctly on the GitHub README view (Action embed loads from the committed SVG; Worker embed loads from the live URL).
- [ ] Confirm the page doesn't shift visibly when one badge is slower to load (200px width is fixed, so there should be no layout jump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)