### PR TITLE
docs(roadmap): track lifecycle state taxonomy port (#15)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,12 +55,14 @@ Test totals: **119 JS + 5 Swift = 124**.
 7. **macOS companion packaging** (no issue yet): Homebrew tap + notarized `.app` build, `LSUIElement = true`.
 8. **Premium pet tier** (no issue yet): optional LLM-driven personality + Imagen visualPrompt for a richer pet on the web.
 9. **Animated spritesheet support** (no issue yet, per the [openai/skills hatch-pet contract](https://github.com/openai/skills/tree/main/skills/.curated/hatch-pet)) — 8×9 atlas, 192×208 cells. Optional tier next to procedural SVG.
+10. **Lifecycle state taxonomy + state-aware SVG** ([#15](https://github.com/schmug/RepoGotchi/issues/15)). Port codex pets' lifecycle vocabulary (`idle / running / failed / review / shipped`) to `state.json` as a separate axis from emotional `mood`. Renderer emits `data-state` on root `<svg>` so per-state visual groups can light up; `<title>` carries a one-line progress hint reused by the menubar tooltip.
 
 ### Open product/design decisions
 
 - **Schema-first vs. inferred**: contract is the source of truth via JSON Schema → TS/Swift codegen. Working well; revisit if Swift codegen drift becomes painful.
 - **Web app**: deliberately not built in v0. Reconsider once the GitHub badge has traction; could be a small Astro marketing site.
 - **Spritesheet tier**: defer until procedural pets feel samey in practice.
+- **Mood vs lifecycle**: `mood` (emotional, score-derived) and `lifecycle` (activity, signal-derived; #15) are kept as separate axes. Revisit if the two start collapsing into the same visual language in practice.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a "Later" item to [ROADMAP.md](ROADMAP.md) pointing at [#15](https://github.com/schmug/RepoGotchi/issues/15) — port codex pets' lifecycle vocabulary (`idle / running / failed / review / shipped`) to `state.json` as a separate axis from emotional `mood`, with `data-state`-aware SVG groups and a one-line progress hint in `<title>`.
- Adds a design-decision note clarifying why `mood` (emotional, score-derived) and `lifecycle` (activity, signal-derived) are kept as separate axes.

## Why

Comparison with the [codex app pets feature](https://developers.openai.com/codex/app/settings#codex-pets) and the [`hatch-pet` skill contract](https://github.com/openai/skills/tree/main/skills/.curated/hatch-pet) surfaced their lifecycle/animation-row vocabulary as orthogonal to RepoGotchi's existing mood. Cheap to port, gives the pet visible immediate reactions to repo activity instead of slow score drift, and aligns our vocabulary with a published industry contract. Implementation is tracked in [#15](https://github.com/schmug/RepoGotchi/issues/15); this PR only updates the roadmap.

## Test plan

- [x] No code changes; docs-only.
- [ ] Reviewer sanity-checks the new "Later" item and the open-decisions note read cleanly in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)